### PR TITLE
[JK-130] Fix issues with jk new command

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -448,12 +448,12 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
 
             for line in template.lines() {
                 if !line.contains("null") {
-                    result = format!("{}{}", result, line)
+                    result = format!("{}{}\n", result, line)
                 }
             }
 
             if *output {
-                error!("{}", result);
+                info!("{}\n", result);
             } else {
                 match name {
                     Some(n) => {


### PR DESCRIPTION
The `jk new` command was not properly inserting new lines into the output.
The output printer when using -o with `jk new` is using the wrong log macro.