### PR TITLE
Feature/jk 143 adjust end messaging

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -7,3 +7,7 @@
 rustflags = ["-C", "target-feature=+crt-static"]
 [target.i686-pc-windows-msvc]
 rustflags = ["-C", "target-feature=+crt-static"]
+
+[profile.release]
+strip = true  # Automatically strip symbols from the binary.
+lto = true # enable link time optimization

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ Next (Version determined when release is cut)
 
 Bugfixes:
 * If a test is not checking response bodies, the test will no longer fail if the response body is not valid JSON.
+* If test runs are configured to exit early on failure, the telemetry session completion and console status messages now properly trigger.
 
 Changes:
 * Adjusted cargo compiler flags for release, greatly reduces release binary size.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Next (Version determined when release is cut)
 =====
 
+Bugfixes:
+* If a test is not checking response bodies, the test will no longer fail if the response body is not valid JSON.
+
+Changes:
+* Adjusted cargo compiler flags for release, greatly reduces release binary size.
+
 0.5.0
 =====
 

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -90,9 +90,14 @@ impl ResultData {
                     status: response_status.as_u16(),
                     body: data,
                 }),
-                Err(e) => {
-                    error!("response is not valid JSON: {}", e);
-                    None
+                Err(e) => { // TODO: add support for non JSON responses
+                    debug!("response is not valid JSON data: {}", e);
+                    debug!("{}", std::str::from_utf8(&resp_data).unwrap_or(""));
+                    Some(ResultData {
+                        headers,
+                        status: response_status.as_u16(),
+                        body: serde_json::Value::Null,
+                    })  
                 }
             },
             Err(e) => {

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -274,7 +274,7 @@ pub async fn complete_stage(
 }
 
 pub async fn complete_session(
-    session: Session,
+    session: &Session,
     runtime: u32,
     status: u32,
 ) -> Result<(), Box<dyn Error + Send + Sync>> {

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -307,7 +307,7 @@ pub async fn complete_session(
         let response = client.request(req).await?;
         let status = response.status();
 
-        if status.as_u16() != 201 {
+        if status.as_u16() != 200 {
             // session creation failed
             debug!("session completion failed: status({})", status);
             return Err(Box::from(TelemetryError {


### PR DESCRIPTION
This fixes both telemetry and status messaging for when exiting test execution early (due to configuration and a failure occurring)..