### PR TITLE
JK-236: fix macos runner to have proper name

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,7 +33,7 @@ jobs:
       
   build-macosx:
     name: macosx build
-    runs-on: macosx-latest
+    runs-on: macos-latest
     steps:
     - uses: actions/checkout@v3
     - name: Build


### PR DESCRIPTION
This was preventing the macos runner from picking up the job.