### PR TITLE
Sanity check that config path is a file. Avoid directory conflict

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -96,7 +96,7 @@ fn get_config_impl(config_sources_ascending_priority: Vec<Option<File>>) -> Conf
 }
 
 async fn load_config_file(file: &str) -> Option<File> {
-    if !Path::new(file).exists() {
+    if !Path::new(file).exists() || !Path::new(file).is_file() {
         return None;
     }
 

--- a/windows_installer.nsi
+++ b/windows_installer.nsi
@@ -1,5 +1,5 @@
 OutFile "jikken-v0.6.1-x86_64-windows.exe"
-InstallDir $PROFILE\.jikken
+InstallDir $PROFILE\.jk
 
 !include "LogicLib.nsh"
 !include "WinMessages.nsh"


### PR DESCRIPTION
On windows, the nsi installer specifies an installer directory of ".jikken" . This conflicts with the cli tool which checks for a file with that name to serve as a possible configuration source. I propose adjusting the name of the directory, as well as adding sanity checks around file consumption for configuration.