### PR TITLE
Fix colors in windows command prompt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -418,6 +418,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 
 [[package]]
+name = "enable-ansi-support"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa4ff3ae2a9aa54bf7ee0983e59303224de742818c1822d89f07da9856d9bc60"
+dependencies = [
+ "windows-sys 0.42.0",
+]
+
+[[package]]
 name = "encode_unicode"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -818,6 +827,7 @@ dependencies = [
  "chrono",
  "clap",
  "dirs",
+ "enable-ansi-support",
  "glob",
  "hex",
  "hyper",
@@ -1983,6 +1993,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
 dependencies = [
  "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ sha2 = { version = "0.10" }
 sysinfo = { version = "0.29" }
 glob = { version = "0.3.1" }
 validated ={ version = "0.4.0" }
+enable-ansi-support = "0.2.1"
 
 [dev-dependencies]
 nonempty-collections = { version="0.1.5" }

--- a/src/main.rs
+++ b/src/main.rs
@@ -270,6 +270,8 @@ async fn run_tests(
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
+    let _ = enable_ansi_support::enable_ansi_support();
+
     let cli = Cli::parse();
     let cli_args = Box::new(serde_json::to_value(&cli)?);
 


### PR DESCRIPTION
The standard windows command prompt (i.e. not the new "Terminal") has known issues with color printing. This addresses the issue for Jikken. 