### PR TITLE
Support for disabling tests

### DIFF
--- a/example_tests/flaky.jkt
+++ b/example_tests/flaky.jkt
@@ -1,0 +1,10 @@
+name: Simulate Flaky Test You Wish to Disable
+requires: auth
+disabled: true
+request:
+  url: https://api.jikken.io/v2/fix_me
+  headers:
+    - header: Authorization
+      value: ${token}
+response:
+  status: 200

--- a/src/test.rs
+++ b/src/test.rs
@@ -30,6 +30,7 @@ pub struct File {
     pub stages: Option<Vec<file::UnvalidatedStage>>,
     pub cleanup: Option<file::UnvalidatedCleanup>,
     pub variables: Option<Vec<file::UnvalidatedVariable>>,
+    pub disabled: Option<bool>,
 
     #[serde(skip_serializing, skip_deserializing)]
     pub filename: String,
@@ -362,6 +363,7 @@ pub struct Definition {
     pub stages: Vec<definition::StageDescriptor>,
     pub setup: Option<definition::RequestResponseDescriptor>,
     pub cleanup: definition::CleanupDescriptor,
+    pub disabled: bool,
 }
 
 // TODO: add validation logic to verify the descriptor is valid
@@ -774,6 +776,7 @@ mod tests {
                 onfailure: None,
                 always: None,
             },
+            disabled: false,
         };
         assert_eq!(None, td.get_body(&None, vars.as_slice(), 1))
     }
@@ -806,6 +809,7 @@ mod tests {
                 onfailure: None,
                 always: None,
             },
+            disabled: false,
         };
 
         let body = RequestBody {
@@ -865,6 +869,7 @@ mod tests {
                 onfailure: None,
                 always: None,
             },
+            disabled: false,
         };
 
         let body = RequestBody {

--- a/src/test/template.rs
+++ b/src/test/template.rs
@@ -21,6 +21,7 @@ pub fn template() -> Result<test::File, Box<dyn Error + Send + Sync>> {
         stages: None,
         cleanup: None,
         variables: None,
+        disabled: None,
     })
 }
 
@@ -41,6 +42,7 @@ pub fn template_staged() -> Result<test::File, Box<dyn Error + Send + Sync>> {
         stages: Some(vec![new_stage()]),
         cleanup: None,
         variables: None,
+        disabled: None,
     })
 }
 
@@ -61,6 +63,7 @@ pub fn template_full() -> Result<test::File, Box<dyn Error + Send + Sync>> {
         stages: Some(vec![new_full_stage()?]),
         cleanup: Some(new_full_cleanup()?),
         variables: Some(vec![new_full_variable()?]),
+        disabled: Some(false),
     })
 }
 

--- a/src/test/validation.rs
+++ b/src/test/validation.rs
@@ -69,6 +69,7 @@ pub fn validate_file(
         )?,
         setup: definition::RequestResponseDescriptor::new_opt(file.setup)?,
         cleanup: definition::CleanupDescriptor::new(file.cleanup)?,
+        disabled: file.disabled.unwrap_or_default(),
     };
 
     td.update_variable_matching();

--- a/vscode_extension/syntaxes/jikken.tmLanguage.json
+++ b/vscode_extension/syntaxes/jikken.tmLanguage.json
@@ -33,7 +33,7 @@
 			"patterns": [
 				{
 					"name": "keyword.control.jikken",
-					"match": "\\b(name|id|env|tags|requires|iterate|setup|request|response|compare|variables|stages|cleanup)\\b"
+					"match": "\\b(name|id|env|tags|requires|iterate|setup|request|response|compare|variables|stages|cleanup|disabled)\\b"
 				},
 				{
 					"include": "#request-keywords"


### PR DESCRIPTION
Add another way to help clients manage their test suite, particularly when dealing with flaky tests. `disabled` provides a means by which to triage tests.