### PR TITLE
Cleaner output

### DIFF
--- a/src/executor.rs
+++ b/src/executor.rs
@@ -303,6 +303,8 @@ async fn run_tests<T: ExecutionPolicy>(
                 }
             }
 
+            log::logger().flush();
+
             test_result.push(result);
         }
         results.push(TestResult {

--- a/src/main.rs
+++ b/src/main.rs
@@ -442,10 +442,15 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
         Level::Info
     };
 
-    let my_logger = SimpleLogger {
-        level: log_level,
-        disabled: cli.quiet,
-    };
+    let my_logger = SimpleLogger::new(
+        log_level,
+        cli.quiet,
+        match cli.command {
+            Commands::Run { .. } => true,
+            Commands::DryRun { .. } => true,
+            _ => false,
+        },
+    );
 
     if let Err(e) = log::set_boxed_logger(Box::new(my_logger)) {
         error!("Error creating logger: {}", e);
@@ -486,6 +491,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
             paths,
         } => {
             updater::check_for_updates().await;
+            log::logger().flush();
             run_tests(
                 paths,
                 tags,
@@ -506,6 +512,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
             paths,
         } => {
             updater::check_for_updates().await;
+            log::logger().flush();
             run_tests(
                 paths,
                 tags,
@@ -540,6 +547,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
             .await?;
         }
     }
+    log::logger().flush();
 
     Ok(())
 }


### PR DESCRIPTION
Have the SimpleLogger support buffered output. When buffered output is enabled, log statements higher than INFO are buffered until a call to flush. This allows for cleaner output when executing tests. Caveats are there is now mutex locking (right now, no contention because we are single threaded) when you log above INFO level. This only happens when you run in debug or trace mode. To mitigate, I could search for/create a lock free queue implementation. 