### PR TITLE
JK-401: Add stdout flush after info logs to force print of partial line

### DIFF
--- a/src/logger.rs
+++ b/src/logger.rs
@@ -1,5 +1,8 @@
 use log::{Level, Log, Metadata, Record};
-use std::sync::Mutex;
+use std::{
+    io::{self, Write},
+    sync::Mutex,
+};
 
 pub struct SimpleLogger {
     pub level: Level,
@@ -22,6 +25,7 @@ impl SimpleLogger {
         match level {
             Level::Info => {
                 print!("{}", message);
+                _ = io::stdout().flush();
             }
             Level::Warn => {
                 println!("\x1b[33m{}\x1b[0m", message);


### PR DESCRIPTION
From `print!` description:

> Prints to the standard output.
> Equivalent to the [`println`] macro except that a newline is not printed at the end of the message.
> **Note that stdout is frequently line-buffered by default so it may be necessary to use `io::stdout().flush` to ensure the output is emitted immediately.**