### PR TITLE
JK-443 -- Better String Variables

### DIFF
--- a/example_tests/complex_checks/inline_body_schema.jkt
+++ b/example_tests/complex_checks/inline_body_schema.jkt
@@ -1,12 +1,20 @@
 name: Inline Body Schema
-requires: auth
 tags: regression flaky triaged
+requires: auth
 request:
-  url: https://animechan.xyz/api/random
+  url: https://api.jikken.io/api/v2/examples/status
+  headers:
+    - header: Authorization
+      value: ${token}
 response:
   status: 200
   bodySchema:
     type: object
     schema:
-      anime: {"type" : "string"}
-      character: {"type" : "string"}  
+      status: {"type" : "string"}
+      user:
+        type: object
+        schema: 
+          username: {"type" : "string"}
+          lastActivity: {"type": "date", "format": "%Y-%m-%d %H:%M:%S%.f %Z"}
+      

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -6,7 +6,7 @@ use crate::test::definition::ResponseDescriptor;
 use crate::test::file::BodyOrSchema;
 use crate::test::file::BodyOrSchemaChecker;
 use crate::test::file::Checker;
-use crate::test::file::ValueOrSpecification;
+use crate::test::file::ValueOrNumericSpecification;
 use crate::test::http;
 use crate::test::http::Header;
 use crate::test::Definition;
@@ -615,7 +615,7 @@ impl ResponseResultData {
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct ExpectedResultData {
     pub headers: Vec<http::Header>,
-    pub status: Option<ValueOrSpecification<u16>>,
+    pub status: Option<ValueOrNumericSpecification<u16>>,
     pub body: Option<BodyOrSchema>,
     pub strict: bool,
 }
@@ -1132,7 +1132,7 @@ fn process_response(
     };
 
     let validate_status_code = |validation_type: &str,
-                                expected: &Option<ValueOrSpecification<u16>>,
+                                expected: &Option<ValueOrNumericSpecification<u16>>,
                                 actual: u16|
      -> Vec<Validated<(), String>> {
         match expected {
@@ -1201,7 +1201,7 @@ fn process_response(
                     ret.append(
                         validate_status_code(
                             "compare ",
-                            &Some(ValueOrSpecification::<u16>::Value(
+                            &Some(ValueOrNumericSpecification::<u16>::Value(
                                 compare_request_result.status,
                             )),
                             resp.status,
@@ -2131,6 +2131,7 @@ fn validate_dry_run(
 
 #[cfg(test)]
 mod tests {
+    use crate::test::file::NumericSpecification;
     use crate::test::file::Specification;
 
     use self::test::definition::ResolvedRequest;
@@ -2146,7 +2147,7 @@ mod tests {
     #[test]
     fn process_response_multiple_failures() {
         let expected = ExpectedResultData {
-            status: Some(ValueOrSpecification::Value(200)),
+            status: Some(ValueOrNumericSpecification::Value(200)),
             body: Some(BodyOrSchema::Body(json!({
                 "Name" : "Bob"
             }))),
@@ -2201,7 +2202,7 @@ mod tests {
     #[test]
     fn process_response_no_result() {
         let expected = ExpectedResultData {
-            status: Some(ValueOrSpecification::Value(1)), //bc we coalesce status to 0 in ResultData::from_request
+            status: Some(ValueOrNumericSpecification::Value(1)), //bc we coalesce status to 0 in ResultData::from_request
             body: None,
             headers: Vec::default(),
             ..ExpectedResultData::new()
@@ -2241,7 +2242,7 @@ mod tests {
     #[test]
     fn process_response_body_mismatch() {
         let expected = ExpectedResultData {
-            status: Some(ValueOrSpecification::Value(200)),
+            status: Some(ValueOrNumericSpecification::Value(200)),
             body: Some(BodyOrSchema::Body(json!({
                 "Name" : "Bob"
             }))),
@@ -2284,7 +2285,7 @@ mod tests {
     #[test]
     fn process_response_body_match() {
         let expected = ExpectedResultData {
-            status: Some(ValueOrSpecification::Value(200)),
+            status: Some(ValueOrNumericSpecification::Value(200)),
             body: Some(BodyOrSchema::Body(json!({
                 "Name" : "Bob"
             }))),
@@ -2327,12 +2328,13 @@ mod tests {
     #[test]
     fn process_response_status_match() {
         let expected = ExpectedResultData {
-            status: Some(ValueOrSpecification::Schema(Specification::<u16> {
-                one_of: Some(vec![200, 201, 202]),
-                value: None,
+            status: Some(ValueOrNumericSpecification::Schema(NumericSpecification {
+                specification: Specification {
+                    one_of: Some(vec![200, 201, 202]),
+                    ..Specification::default()
+                },
                 min: None,
                 max: None,
-                none_of: None,
             })),
             body: None,
             headers: Vec::default(),
@@ -2372,7 +2374,7 @@ mod tests {
     #[test]
     fn process_response_status_mismatch() {
         let expected = ExpectedResultData {
-            status: Some(ValueOrSpecification::Value(200)),
+            status: Some(ValueOrNumericSpecification::Value(200)),
             body: None,
             headers: Vec::default(),
             ..ExpectedResultData::new()

--- a/src/new.rs
+++ b/src/new.rs
@@ -2,8 +2,9 @@ use super::errors::GenericError;
 use super::test::template;
 use log::{error, info};
 
+use crate::test::file::NumericSpecification;
 use crate::test::file::Specification;
-use crate::test::file::ValueOrSpecification;
+use crate::test::file::ValueOrNumericSpecification;
 use crate::test::http;
 use crate::test::File;
 use std::error::Error;
@@ -19,20 +20,22 @@ fn create_tags(tags: &[String]) -> Option<String> {
     }
 }
 
-fn create_status_code(status_code_pattern: &str) -> Option<ValueOrSpecification<u16>> {
+fn create_status_code(status_code_pattern: &str) -> Option<ValueOrNumericSpecification<u16>> {
     if status_code_pattern == "2XX" {
-        Some(ValueOrSpecification::Schema(Specification {
-            value: None,
+        Some(ValueOrNumericSpecification::Schema(NumericSpecification {
+            specification: Specification {
+                value: None,
+                one_of: None,
+                none_of: None,
+            },
             min: Some(200),
             max: Some(299),
-            one_of: None,
-            none_of: None,
         }))
     } else {
         status_code_pattern
             .parse()
             .ok()
-            .map(ValueOrSpecification::Value)
+            .map(ValueOrNumericSpecification::Value)
     }
 }
 
@@ -453,12 +456,6 @@ mod openapi_v31 {
                 ObjectOrReference::Ref { .. } => None,
                 ObjectOrReference::Object(t) => Some(test::file::UnvalidatedVariable {
                     name: t.name.clone(),
-
-                    //t.
-                    //data_type: None,
-                    //file: None,
-                    //format: None,
-                    //modifier: None,
                     value: test::file::StringOrDatumOrFile::Value {
                         value: "".to_string(),
                     },
@@ -708,12 +705,13 @@ pub async fn create_test_template(
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::test::file::ValueOrSpecification;
+    use crate::test::file::Specification;
+    use crate::test::file::ValueOrNumericSpecification;
 
     #[test]
     fn create_status_code_number_ok() {
         assert_eq!(
-            Some(ValueOrSpecification::Value(204)),
+            Some(ValueOrNumericSpecification::Value(204)),
             create_status_code("204")
         );
     }
@@ -721,12 +719,10 @@ mod test {
     #[test]
     fn create_status_code_pattern_ok() {
         assert_eq!(
-            Some(ValueOrSpecification::Schema(Specification::<u16> {
-                value: None,
+            Some(ValueOrNumericSpecification::Schema(NumericSpecification {
+                specification: Specification::<u16>::default(),
                 min: Some(200),
                 max: Some(299),
-                none_of: None,
-                one_of: None
             })),
             create_status_code("2XX")
         );

--- a/src/test/definition.rs
+++ b/src/test/definition.rs
@@ -1,5 +1,5 @@
 use crate::test;
-use crate::test::file::ValueOrSpecification;
+use crate::test::file::ValueOrNumericSpecification;
 use crate::test::{file, http, validation};
 use serde::{Deserialize, Serialize};
 use std::cell::Cell;
@@ -203,7 +203,7 @@ impl ResponseExtraction {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ResponseDescriptor {
-    pub status: Option<ValueOrSpecification<u16>>,
+    pub status: Option<ValueOrNumericSpecification<u16>>,
     pub headers: Vec<http::Header>,
     pub body: Option<RequestBody>,
     pub ignore: Vec<String>,

--- a/src/test/template.rs
+++ b/src/test/template.rs
@@ -98,7 +98,7 @@ fn new_response() -> file::UnvalidatedResponse {
 
 fn new_full_response() -> Result<file::UnvalidatedResponse, Box<dyn Error + Send + Sync>> {
     Ok(file::UnvalidatedResponse {
-        status: Some(test::file::ValueOrSpecification::Value(200)),
+        status: Some(test::file::ValueOrNumericSpecification::Value(200)),
         headers: Some(vec![new_header()]),
         body: Some(serde_json::from_str("{}")?),
         ignore: Some(vec!["".to_string()]),

--- a/src/test/variable.rs
+++ b/src/test/variable.rs
@@ -1,24 +1,6 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Hash)]
-pub enum Type {
-    #[serde(alias = "int", alias = "INT")]
-    Int,
-    #[serde(alias = "string", alias = "STRING")]
-    String,
-    #[serde(alias = "date", alias = "DATE")]
-    Date,
-    #[serde(alias = "datetime", alias = "DATETIME")]
-    Datetime,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct Range {
-    pub min: String,
-    pub max: String,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Hash)]
 pub struct Modifier {
     pub operation: String,
     pub value: String,


### PR DESCRIPTION
- String variables shouldn't have "max" and "min'. They should have "maxLength" and "minLength" . 
- Factor out common behavior of all the specification types into `Specification` that can be leveraged by each type through composition. 
- Reimplement numeric type specifications to eliminate copied code.  
- Move off of animechan in favor of Jikken APIs
- Remove dead code from the variable module ( we should probably migrate specification-related code to that module)