### PR TITLE
Jk-464 -- Improve List and Object Variables

### DIFF
--- a/example_tests/complex_checks/body_schema_variable.jkt
+++ b/example_tests/complex_checks/body_schema_variable.jkt
@@ -1,0 +1,21 @@
+name: Complex Check Using Body Schema Variable
+tags: regression flaky triaged
+requires: auth
+request:
+  url: https://api.jikken.io/api/v2/examples/status
+  headers:
+    - header: Authorization
+      value: ${token}
+response:
+  status: 200
+  bodySchema: ${expected_response_schema}
+variables:
+  - name: expected_response_schema
+    type: object
+    schema:
+      status: Active
+      user:
+        type: object
+        schema: 
+          username: testuser
+          lastActivity: {"type": "date", "format": "%Y-%m-%d %H:%M:%S%.f %Z"}

--- a/src/config.rs
+++ b/src/config.rs
@@ -61,9 +61,9 @@ impl Config {
             .chain(self.globals.iter())
             .map(|i| test::Variable {
                 name: i.0.to_string(),
-                value: test::StringOrDatumOrFileOrSecret::Value {
-                    value: i.1.to_string(),
-                },
+                value: test::StringOrDatumOrFileOrSecret::Value(serde_json::Value::from(
+                    i.1.to_string(),
+                )),
                 source_path: "./".to_string(),
             })
             .chain(

--- a/src/new.rs
+++ b/src/new.rs
@@ -206,7 +206,7 @@ mod openapi_legacy {
                 RefOr::Item(t) => Some(test::file::UnvalidatedVariable {
                     name: t.name.clone(),
                     value: test::file::StringOrDatumOrFile::Value {
-                        value: "value".to_string(),
+                        value: serde_json::Value::from("value".to_string()),
                     },
                 }),
             })
@@ -453,7 +453,7 @@ mod openapi_v31 {
                 ObjectOrReference::Object(t) => Some(test::file::UnvalidatedVariable {
                     name: t.name.clone(),
                     value: test::file::StringOrDatumOrFile::Value {
-                        value: "".to_string(),
+                        value: serde_json::Value::from("".to_string()),
                     },
                 }),
             })

--- a/src/test/template.rs
+++ b/src/test/template.rs
@@ -87,7 +87,7 @@ fn new_full_variables() -> Result<file::UnvalidatedVariable, Box<dyn Error + Sen
     Ok(file::UnvalidatedVariable {
         name: "".to_string(),
         value: file::StringOrDatumOrFile::Value {
-            value: "".to_string(),
+            value: serde_json::Value::from("".to_string()),
         },
     })
 }

--- a/src/test/variable.rs
+++ b/src/test/variable.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Hash, PartialOrd)]
 pub struct Modifier {
     pub operation: String,
     pub value: String,


### PR DESCRIPTION
- The List type can be heterogeneous
- The Object type can now not only hold DatumSchemas but serde_json::Value's as well
- All literal variables are now serde_json::Value's
- Literal variables now support strings, numbers, lists, and objects
- No longer will you specify explicit value variables in the following form due to above
`name: foo
 type: String
 value: hello world
 `
- BodySchemas can now be specified with variables, 
- AnyOf constraint introduced which allows you to say that any of the following schema's can match vs OneOf which says that ONLY 1 may match. This really shines for lists and most users won't even need it for that, but it does offer ultimate flexibility.
- Lists can specify max and min lengths
- You can specify that a list should have any_of OR one_of OR none_of defined schemas OR explicit values . This brings the data type more in line with our other supported types. As an added bonus, the pre-existing and simple syntax for specifying constraints for lists still works. The following are valid examples of list variables.
```
variables: 
  - name: literal
     value: [ "literal", "values", "in", "array" ]
  - name: postcodes
    type: list
    maxLength: 3
    schema:
      type: string
  - name: sample_array
    type: list
    schema:
      anyOf: 
        - type: string
        - type: int
        - type: date
  - name: sample_array2
    type: list
    schema:
      oneOf:
        - [1, 2, 3 , 4]
        - ["hello", "world"]
    ```
