### PR TITLE
JK-469 -- Support for variables in more places

### DIFF
--- a/example_tests/complex_checks/body_schema_variable.jkt
+++ b/example_tests/complex_checks/body_schema_variable.jkt
@@ -1,10 +1,6 @@
 name: Complex Check Using Body Schema Variable
 tags: regression flaky triaged
-description: |
-  BodySchema as a variable does not work due to some issues
-  in this early version. Will be addressed soon. 
 requires: auth
-disabled: true
 request:
   url: https://api.jikken.io/api/v2/examples/status
   headers:
@@ -12,7 +8,7 @@ request:
       value: ${token}
 response:
   status: 200
-  #bodySchema: ${expected_response_schema}
+  bodySchema: ${expected_response_schema}
 variables:
   - name: expected_response_schema
     type: object

--- a/src/test/validation.rs
+++ b/src/test/validation.rs
@@ -47,6 +47,14 @@ pub fn validate_file(
 
     let generated_id = file.generate_id();
 
+    let variables = test::Variable::validate_variables_opt(
+        file.variables,
+        PathBuf::from(&file.filename)
+            .parent()
+            .and_then(|p| p.to_str())
+            .unwrap_or(&file.filename),
+    )?;
+
     let td = test::Definition {
         name: file.name,
         description: file.description,
@@ -56,13 +64,7 @@ pub fn validate_file(
         requires: file.requires,
         tags: new_tags,
         iterate: file.iterate.unwrap_or(1),
-        variables: test::Variable::validate_variables_opt(
-            file.variables,
-            PathBuf::from(&file.filename)
-                .parent()
-                .and_then(|p| p.to_str())
-                .unwrap_or(&file.filename),
-        )?,
+        variables: variables.clone(),
         global_variables: global_variables.to_vec(),
         stages: definition::StageDescriptor::validate_stages_opt(
             file.request,
@@ -70,9 +72,10 @@ pub fn validate_file(
             file.response,
             file.stages,
             &variable::parse_source_path(&file.filename),
+            &variables,
         )?,
-        setup: definition::RequestResponseDescriptor::new_opt(file.setup)?,
-        cleanup: definition::CleanupDescriptor::new(file.cleanup)?,
+        setup: definition::RequestResponseDescriptor::new_opt(file.setup, &variables)?,
+        cleanup: definition::CleanupDescriptor::new(file.cleanup, &variables)?,
         disabled: file.disabled.unwrap_or_default(),
         filename: file.filename,
     };


### PR DESCRIPTION
Support variables in body and bodyschema. Introduce a new type for variable references with special deserialization rules to make this easier. Probably the basis for variable existence validation.