### PR TITLE
JK-498: Add length field for string and list generation/validation

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ mod new;
 mod telemetry;
 mod test;
 mod updater;
+mod validated;
 
 use clap::{Parser, Subcommand};
 use glob::{glob_with, MatchOptions};

--- a/src/new.rs
+++ b/src/new.rs
@@ -147,6 +147,7 @@ mod openapi_legacy {
                                     Specification::<Box<DatumSchema>>::Value(Box::from(ds)),
                                 )
                             }),
+                            length: Option::None,
                             min_length: a.min_items.map(|s| s as i64),
                             max_length: a.max_items.map(|s| s as i64),
                         }),
@@ -190,6 +191,7 @@ mod openapi_legacy {
                 }
                 openapiv3::Type::String(string) => {
                     let string_spec = StringSpecification {
+                        length: Option::None,
                         max_length: string.max_length.map(|s| s as i64),
                         min_length: string.min_length.map(|s| s as i64),
                         pattern: string.pattern.clone(),
@@ -572,6 +574,7 @@ mod openapi_v31 {
                             })
                         })
                     }),
+                    length: Option::None,
                     max_length: schema.max_items.map(|n| n as i64),
                     min_length: schema.min_items.map(|n| n as i64),
                 }),
@@ -629,6 +632,7 @@ mod openapi_v31 {
             oas3::spec::SchemaType::String => {
                 let string_spec = StringSpecification {
                     pattern: schema.pattern,
+                    length: Option::None,
                     max_length: schema.max_length.map(|n| n as i64),
                     min_length: schema.min_length.map(|n| n as i64),
                     ..Default::default()

--- a/src/test.rs
+++ b/src/test.rs
@@ -135,13 +135,19 @@ impl TryFrom<ValueOrDatumOrFile> for ValueOrDatumOrFileOrSecret {
                     }),
                     DatumSchema::List { specification } => specification
                         .map(|s| {
-                            SequenceSpecification::new(s.schema, s.min_length, s.max_length).map(
-                                |s| ValueOrDatumOrFileOrSecret::Schema {
+                            SequenceSpecification::new(
+                                s.schema,
+                                s.length,
+                                s.min_length,
+                                s.max_length,
+                            )
+                            .map(|s| {
+                                ValueOrDatumOrFileOrSecret::Schema {
                                     value: DatumSchema::List {
                                         specification: Some(s),
                                     },
-                                },
-                            )
+                                }
+                            })
                         })
                         .unwrap_or(Ok(ValueOrDatumOrFileOrSecret::Schema {
                             value: DatumSchema::List {
@@ -202,6 +208,7 @@ impl TryFrom<ValueOrDatumOrFile> for ValueOrDatumOrFileOrSecret {
                         .map(|s| {
                             StringSpecification::new(
                                 s.specification,
+                                s.length,
                                 s.min_length,
                                 s.max_length,
                                 s.pattern,

--- a/src/validated.rs
+++ b/src/validated.rs
@@ -1,0 +1,119 @@
+use nonempty_collections::NEVec;
+use validated::{
+    Validated,
+    Validated::{Fail, Good},
+};
+
+pub trait ValidatedExt<T, E> {
+    fn map5<U, V, W, X, Z, F>(
+        self,
+        vu: Validated<U, E>,
+        vv: Validated<V, E>,
+        vw: Validated<W, E>,
+        vx: Validated<X, E>,
+        f: F,
+    ) -> Validated<Z, E>
+    where
+        F: FnOnce(T, U, V, W, X) -> Z;
+}
+
+impl<T, E> ValidatedExt<T, E> for Validated<T, E> {
+    /// Maps a function over five `Validated`, but only if all five are of the
+    /// `Good` variant. If any failed, then their errors are concatenated.
+    fn map5<U, V, W, X, Z, F>(
+        self,
+        vu: Validated<U, E>,
+        vv: Validated<V, E>,
+        vw: Validated<W, E>,
+        vx: Validated<X, E>,
+        f: F,
+    ) -> Validated<Z, E>
+    where
+        F: FnOnce(T, U, V, W, X) -> Z,
+    {
+        match (self, vu, vv, vw, vx) {
+            (Good(t), Good(u), Good(v), Good(w), Good(x)) => Good(f(t, u, v, w, x)),
+
+            (Good(_), Good(_), Good(_), Good(_), Fail(e)) => Fail(e),
+            (Good(_), Good(_), Good(_), Fail(e), Good(_)) => Fail(e),
+            (Good(_), Good(_), Fail(e), Good(_), Good(_)) => Fail(e),
+            (Good(_), Fail(e), Good(_), Good(_), Good(_)) => Fail(e),
+            (Fail(e), Good(_), Good(_), Good(_), Good(_)) => Fail(e),
+
+            (Good(_), Good(_), Good(_), Fail(e0), Fail(e1)) => Fail(nons(e0, Some(e1).into_iter())),
+            (Good(_), Good(_), Fail(e0), Good(_), Fail(e1)) => Fail(nons(e0, Some(e1).into_iter())),
+            (Good(_), Fail(e0), Good(_), Good(_), Fail(e1)) => Fail(nons(e0, Some(e1).into_iter())),
+            (Fail(e0), Good(_), Good(_), Good(_), Fail(e1)) => Fail(nons(e0, Some(e1).into_iter())),
+            (Good(_), Good(_), Fail(e0), Fail(e1), Good(_)) => Fail(nons(e0, Some(e1).into_iter())),
+            (Good(_), Fail(e0), Good(_), Fail(e1), Good(_)) => Fail(nons(e0, Some(e1).into_iter())),
+            (Fail(e0), Good(_), Good(_), Fail(e1), Good(_)) => Fail(nons(e0, Some(e1).into_iter())),
+            (Good(_), Fail(e0), Fail(e1), Good(_), Good(_)) => Fail(nons(e0, Some(e1).into_iter())),
+            (Fail(e0), Good(_), Fail(e1), Good(_), Good(_)) => Fail(nons(e0, Some(e1).into_iter())),
+            (Fail(e0), Fail(e1), Good(_), Good(_), Good(_)) => Fail(nons(e0, Some(e1).into_iter())),
+
+            (Good(_), Good(_), Fail(e0), Fail(e1), Fail(e2)) => {
+                Fail(nons(e0, vec![e1, e2].into_iter()))
+            }
+            (Good(_), Fail(e0), Good(_), Fail(e1), Fail(e2)) => {
+                Fail(nons(e0, vec![e1, e2].into_iter()))
+            }
+            (Fail(e0), Good(_), Good(_), Fail(e1), Fail(e2)) => {
+                Fail(nons(e0, vec![e1, e2].into_iter()))
+            }
+            (Good(_), Fail(e0), Fail(e1), Good(_), Fail(e2)) => {
+                Fail(nons(e0, vec![e1, e2].into_iter()))
+            }
+            (Fail(e0), Good(_), Fail(e1), Good(_), Fail(e2)) => {
+                Fail(nons(e0, vec![e1, e2].into_iter()))
+            }
+            (Fail(e0), Fail(e1), Good(_), Good(_), Fail(e2)) => {
+                Fail(nons(e0, vec![e1, e2].into_iter()))
+            }
+            (Good(_), Fail(e0), Fail(e1), Fail(e2), Good(_)) => {
+                Fail(nons(e0, vec![e1, e2].into_iter()))
+            }
+            (Fail(e0), Good(_), Fail(e1), Fail(e2), Good(_)) => {
+                Fail(nons(e0, vec![e1, e2].into_iter()))
+            }
+            (Fail(e0), Fail(e1), Good(_), Fail(e2), Good(_)) => {
+                Fail(nons(e0, vec![e1, e2].into_iter()))
+            }
+            (Fail(e0), Fail(e1), Fail(e2), Good(_), Good(_)) => {
+                Fail(nons(e0, vec![e1, e2].into_iter()))
+            }
+
+            (Good(_), Fail(e0), Fail(e1), Fail(e2), Fail(e3)) => {
+                Fail(nons(e0, vec![e1, e2, e3].into_iter()))
+            }
+            (Fail(e0), Good(_), Fail(e1), Fail(e2), Fail(e3)) => {
+                Fail(nons(e0, vec![e1, e2, e3].into_iter()))
+            }
+            (Fail(e0), Fail(e1), Good(_), Fail(e2), Fail(e3)) => {
+                Fail(nons(e0, vec![e1, e2, e3].into_iter()))
+            }
+            (Fail(e0), Fail(e1), Fail(e2), Good(_), Fail(e3)) => {
+                Fail(nons(e0, vec![e1, e2, e3].into_iter()))
+            }
+            (Fail(e0), Fail(e1), Fail(e2), Fail(e3), Good(_)) => {
+                Fail(nons(e0, vec![e1, e2, e3].into_iter()))
+            }
+
+            (Fail(e0), Fail(e1), Fail(e2), Fail(e3), Fail(e4)) => {
+                Fail(nons(e0, vec![e1, e2, e3, e4].into_iter()))
+            }
+        }
+    }
+}
+
+/// Fuse some `NEVec`s together.
+fn nons<E, I>(mut a: NEVec<E>, rest: I) -> NEVec<E>
+where
+    I: Iterator<Item = NEVec<E>>,
+{
+    for mut i in rest {
+        a.push(i.head);
+        a.append(&mut i.tail)
+    }
+
+    a
+}


### PR DESCRIPTION
To specify exact length, instead of having the same value for minLength and maxLength.