### PR TITLE
JK-517: Add validation for variable names

### DIFF
--- a/src/test.rs
+++ b/src/test.rs
@@ -367,7 +367,7 @@ impl Variable {
         let regex = Regex::new(r"(?i)^[a-z0-9-_]+$").unwrap();
         if !regex.is_match(variable.name.as_str()) {
             debug!("variable name '{}' is invalid", variable.name);
-            return Err(validation::Error{reason: "name invalid - may only contain alphanumeric characters, hyphens, and underscores".to_string()});
+            return Err(validation::Error{reason: "name is invalid - may only contain alphanumeric characters, hyphens, and underscores".to_string()});
         }
 
         variable


### PR DESCRIPTION
Must contain at least one character, and may only contain letters, numbers, hyphens, and underscores.

Example of full message:
> Test "Generate all the things" failed validation: variable "body.invalid" name is invalid - must only contain alphanumeric characters, hyphens, and underscores.