### PR TITLE
JK-538: Make test id optional and remove auto-generation

### DIFF
--- a/src/executor.rs
+++ b/src/executor.rs
@@ -2582,7 +2582,7 @@ mod tests {
         test::Definition {
             name: None,
             description: None,
-            id: String::from(id),
+            id: Some(id.to_string()),
             platform_id: None,
             project: None,
             environment: None,
@@ -2669,7 +2669,7 @@ mod tests {
         test::Definition {
             name: None,
             description: None,
-            id: String::from("id"),
+            id: None,
             platform_id: None,
             project: None,
             environment: None,

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -1043,10 +1043,8 @@ pub async fn execute_tests(
                         return Report::default();
                     }
                 }
-            } else {
-                if let Err(failures) = validation_results {
-                    print_validation_failures(failures, false);
-                }
+            } else if let Err(failures) = validation_results {
+                print_validation_failures(failures, false);
             }
         } else {
             debug!("invalid api token: {}", &token);

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -734,12 +734,13 @@ fn validate_test_file(
     global_variables: &[test::Variable],
     project: Option<String>,
     environment: Option<String>,
+    index: usize,
 ) -> Option<test::Definition> {
     let name = test_file
         .name
         .clone()
         .unwrap_or_else(|| test_file.filename.clone());
-    let res = validation::validate_file(test_file, global_variables, project, environment);
+    let res = validation::validate_file(test_file, global_variables, project, environment, index);
     match res {
         Ok(file) => Some(file),
         Err(e) => {
@@ -2578,6 +2579,7 @@ mod tests {
     fn construct_definition_for_dependency_graph(
         id: &str,
         requires: Option<String>,
+        index: usize,
     ) -> test::Definition {
         test::Definition {
             name: None,
@@ -2600,6 +2602,7 @@ mod tests {
             },
             disabled: false,
             filename: "/a/path.jkt".to_string(),
+            index,
         }
     }
 
@@ -2687,6 +2690,7 @@ mod tests {
             },
             disabled: false,
             filename: "/a/path.jkt".to_string(),
+            index: 0,
         }
     }
 

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -521,7 +521,7 @@ pub fn validate_platform_ids(
             continue;
         };
 
-        let Ok(id) = Ulid::from_string(&id_raw) else {
+        let Ok(id) = Ulid::from_string(id_raw) else {
             failures.push((definition, PlatformIdFailure::Invalid));
             continue;
         };
@@ -533,7 +533,7 @@ pub fn validate_platform_ids(
         duplicate_check.insert(id);
     }
 
-    if failures.len() > 0 {
+    if !failures.is_empty() {
         return Err(failures);
     }
 

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -68,7 +68,7 @@ pub struct Test {
 #[serde(rename_all = "camelCase")]
 struct TestPost {
     pub session_id: String,
-    pub identifier: String,
+    pub identifier: Option<String>,
     pub platform_id: ulid::Ulid,
     pub definition: serde_json::Value,
 }
@@ -292,7 +292,7 @@ pub async fn create_test(
 
     let post_body = TestPost {
         session_id: session.session_id.to_string(),
-        identifier: pruned_definition.id.clone(),
+        identifier: pruned_definition.id,
         platform_id: ulid,
         definition: definition_json,
     };
@@ -594,7 +594,7 @@ mod tests {
         let td = test::Definition {
             name: None,
             description: None,
-            id: String::from("id"),
+            id: None,
             platform_id: None,
             project: None,
             environment: None,
@@ -715,7 +715,7 @@ mod tests {
         let td = test::Definition {
             name: None,
             description: None,
-            id: String::from("id"),
+            id: None,
             platform_id: None,
             project: None,
             environment: None,
@@ -786,7 +786,7 @@ mod tests {
         let td = test::Definition {
             name: None,
             description: None,
-            id: String::from("id"),
+            id: None,
             platform_id: None,
             project: None,
             environment: None,

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -634,6 +634,7 @@ mod tests {
             },
             disabled: false,
             filename: "/a/path.jkt".to_string(),
+            index: 0,
         };
 
         let get_all_headers = |td: test::Definition| -> Vec<Header> {
@@ -761,6 +762,7 @@ mod tests {
             },
             disabled: false,
             filename: "/a/path.jkt".to_string(),
+            index: 0,
         };
         let before = td.clone();
         let pruned = remove_temporal_values(td);
@@ -826,6 +828,7 @@ mod tests {
             },
             disabled: false,
             filename: "/a/path.jkt".to_string(),
+            index: 0,
         };
         let before = td.clone();
         let pruned = remove_temporal_values(td);

--- a/src/test.rs
+++ b/src/test.rs
@@ -536,6 +536,9 @@ pub struct Definition {
 
     #[serde(skip_serializing, skip_deserializing)]
     pub filename: String,
+
+    #[serde(skip_serializing, skip_deserializing)]
+    pub index: usize,
 }
 
 // TODO: add validation logic to verify the descriptor is valid
@@ -1276,6 +1279,7 @@ mod tests {
             },
             disabled: false,
             filename: "/a/path.jkt".to_string(),
+            index: 0,
         };
         assert_eq!(
             None,
@@ -1313,6 +1317,7 @@ mod tests {
             },
             disabled: false,
             filename: "/a/path.jkt".to_string(),
+            index: 0,
         };
 
         let body = RequestBody {
@@ -1375,6 +1380,7 @@ mod tests {
             },
             disabled: false,
             filename: "/a/path.jkt".to_string(),
+            index: 0,
         };
 
         let body = RequestBody {

--- a/src/test.rs
+++ b/src/test.rs
@@ -29,7 +29,6 @@ use std::fmt::{self};
 use std::hash::{Hash, Hasher};
 use std::path::Path;
 use ulid::Ulid;
-use uuid::Uuid;
 
 #[derive(Deserialize, PartialEq)]
 pub struct SecretValue(String);
@@ -343,7 +342,7 @@ impl Default for File {
         Self {
             filename: "".to_string(),
             name: Some("".to_string()),
-            id: Some(Uuid::new_v4().to_string()),
+            id: None,
             platform_id: Some(Ulid::new().to_string()),
             project: None,
             env: None,
@@ -530,7 +529,7 @@ impl Variable {
 pub struct Definition {
     pub name: Option<String>,
     pub description: Option<String>,
-    pub id: String,
+    pub id: Option<String>,
     pub platform_id: Option<String>,
     pub project: Option<String>,
     pub environment: Option<String>,
@@ -1268,7 +1267,7 @@ mod tests {
         let td = Definition {
             name: None,
             description: None,
-            id: "id".to_string(),
+            id: None,
             platform_id: None,
             project: None,
             environment: None,
@@ -1299,7 +1298,7 @@ mod tests {
         let td = Definition {
             name: None,
             description: None,
-            id: "id".to_string(),
+            id: None,
             platform_id: None,
             project: None,
             environment: None,
@@ -1355,7 +1354,7 @@ mod tests {
         let td = Definition {
             name: None,
             description: None,
-            id: "id".to_string(),
+            id: None,
             platform_id: None,
             project: None,
             environment: None,

--- a/src/test.rs
+++ b/src/test.rs
@@ -22,7 +22,6 @@ use log::{debug, error, trace};
 use regex::Regex;
 use serde::Serializer;
 use serde::{Deserialize, Serialize};
-use std::collections::hash_map::DefaultHasher;
 use std::collections::{HashMap, HashSet};
 use std::fmt::Debug;
 use std::fmt::{self};
@@ -359,14 +358,6 @@ impl Default for File {
             disabled: None,
             description: None,
         }
-    }
-}
-
-impl File {
-    pub fn generate_id(&self) -> String {
-        let mut s = DefaultHasher::new();
-        self.hash(&mut s);
-        format!("{}", s.finish())
     }
 }
 

--- a/src/test/validation.rs
+++ b/src/test/validation.rs
@@ -84,7 +84,7 @@ pub fn validate_file(
     let td = test::Definition {
         name: file.name,
         description: file.description,
-        id: file.id,
+        id: file.id.map(|i| i.to_lowercase()),
         platform_id: file.platform_id,
         project: file.project.or(project),
         environment: file.env.or(environment),

--- a/src/test/validation.rs
+++ b/src/test/validation.rs
@@ -61,6 +61,7 @@ pub fn validate_file(
     global_variables: &[test::Variable],
     project: Option<String>,
     environment: Option<String>,
+    index: usize,
 ) -> Result<test::Definition, Error> {
     validate_test_file(&file, global_variables)?;
     let new_tags = if let Some(tags) = file.tags.as_ref() {
@@ -104,6 +105,7 @@ pub fn validate_file(
         cleanup: definition::CleanupDescriptor::new(file.cleanup, &variables)?,
         disabled: file.disabled.unwrap_or_default(),
         filename: file.filename,
+        index,
     };
 
     td.update_variable_matching();

--- a/src/test/validation.rs
+++ b/src/test/validation.rs
@@ -72,8 +72,6 @@ pub fn validate_file(
         Vec::new()
     };
 
-    let generated_id = file.generate_id();
-
     let variables = test::Variable::validate_variables_opt(
         file.variables,
         PathBuf::from(&file.filename)
@@ -85,7 +83,7 @@ pub fn validate_file(
     let td = test::Definition {
         name: file.name,
         description: file.description,
-        id: file.id.unwrap_or(generated_id).to_lowercase(),
+        id: file.id,
         platform_id: file.platform_id,
         project: file.project.or(project),
         environment: file.env.or(environment),


### PR DESCRIPTION
Also update test dependency graph to identify tests by index instead of id